### PR TITLE
add missing enum value to models.py

### DIFF
--- a/mtg_ssm/scryfall/models.py
+++ b/mtg_ssm/scryfall/models.py
@@ -118,6 +118,7 @@ class ScryFrameEffect(str, Enum):
     NYXBORN = "nyxborn"
     NYXTOUCHED = "nyxtouched"
     ORIGINPWDFC = "originpwdfc"
+    PROMO = "promo"
     SHATTEREDGLASS = "shatteredglass"
     SHOWCASE = "showcase"
     SNOW = "snow"


### PR DESCRIPTION
figured I would try and help out and it's a simple change.. 
This fixes #56 

Ran the tests against it... Didn't see it in the contribution guidelines, but hey, they should pass right? :)

```
pytest --snapshot-update       
=============================================== test session starts ================================================
platform linux -- Python 3.10.12, pytest-8.1.1, pluggy-1.4.0
rootdir: /home/tony/projects/mtg_ssm
configfile: pyproject.toml
testpaths: tests
plugins: syrupy-4.6.1, cov-5.0.0
collected 106 items                                                                                                

tests/containers/test_bundles.py ....                                                                        [  3%]
tests/containers/test_counts.py .............x..x.....                                                       [ 24%]
tests/containers/test_indexes.py .......                                                                     [ 31%]
tests/containers/test_legacy.py ......x.....x.....                                                           [ 48%]
tests/mtg/test_util.py ..........                                                                            [ 57%]
tests/scryfall/test_fetcher.py ..                                                                            [ 59%]
tests/serialization/test_csv.py .......                                                                      [ 66%]
tests/serialization/test_interface.py .....xx                                                                [ 72%]
tests/serialization/test_xlsx.py ...............                                                             [ 86%]
tests/test_ssm.py ..............                                                                             [100%]

================================================= warnings summary =================================================
tests/scryfall/test_fetcher.py::test_scryfetch
tests/scryfall/test_fetcher.py::test_scryfetch
tests/scryfall/test_fetcher.py::test_scryfetch
tests/scryfall/test_fetcher.py::test_scryfetch
tests/scryfall/test_fetcher.py::test_data_fixtures
tests/scryfall/test_fetcher.py::test_data_fixtures
tests/scryfall/test_fetcher.py::test_data_fixtures
tests/scryfall/test_fetcher.py::test_data_fixtures
  /home/tony/.local/lib/python3.10/site-packages/responses/__init__.py:436: DeprecationWarning: Argument 'match_querystring' is deprecated. Use 'responses.matchers.query_param_matcher' or 'responses.matchers.query_string_matcher'
    warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

---------- coverage: platform linux, python 3.10.12-final-0 ----------
Name                                 Stmts   Miss  Cover   Missing
------------------------------------------------------------------
mtg_ssm/__init__.py                      4      2    50%   5-6
mtg_ssm/_version.py                     11      2    82%   5-6
mtg_ssm/containers/__init__.py           0      0   100%
mtg_ssm/containers/bundles.py           42      1    98%   37
mtg_ssm/containers/collection.py        27      9    67%   20-22, 29, 35, 42-45
mtg_ssm/containers/counts.py            53      0   100%
mtg_ssm/containers/indexes.py           70      0   100%
mtg_ssm/containers/legacy.py            50      1    98%   134
mtg_ssm/mtg/__init__.py                  0      0   100%
mtg_ssm/mtg/util.py                     20      0   100%
mtg_ssm/scryfall/__init__.py             0      0   100%
mtg_ssm/scryfall/fetcher.py             42      2    95%   72-75
mtg_ssm/scryfall/models.py             341      0   100%
mtg_ssm/serialization/__init__.py        2      0   100%
mtg_ssm/serialization/csv.py            37      0   100%
mtg_ssm/serialization/interface.py      33      0   100%
mtg_ssm/serialization/xlsx.py          155      1    99%   145
mtg_ssm/ssm.py                         123     13    89%   33-38, 48-53, 189-198, 283-291, 295
------------------------------------------------------------------
TOTAL                                 1010     31    97%

--------------------------------------------- snapshot report summary ----------------------------------------------
7 snapshots passed. 12 snapshots updated.
==================================== 100 passed, 6 xfailed, 8 warnings in 0.44s ====================================
```
